### PR TITLE
Revert "Use absolute paths in #line directives generated"

### DIFF
--- a/src/arduino.cc/builder/sketch_source_merger.go
+++ b/src/arduino.cc/builder/sketch_source_merger.go
@@ -32,6 +32,7 @@ package builder
 import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
+	"path/filepath"
 )
 
 type SketchSourceMerger struct{}
@@ -51,7 +52,7 @@ func (s *SketchSourceMerger) Run(context map[string]interface{}) error {
 }
 
 func addPreprocLine(sketch *types.SketchFile) string {
-	source := "#line 1 \"" + sketch.Name + "\"\n"
+	source := "#line 1 \"" + filepath.Base(sketch.Name) + "\"\n"
 	source += sketch.Source
 	source += "\n"
 

--- a/src/arduino.cc/builder/test/coan_runner_test.go
+++ b/src/arduino.cc/builder/test/coan_runner_test.go
@@ -34,6 +34,7 @@ import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
 	"github.com/stretchr/testify/require"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -67,7 +68,10 @@ func TestCoanRunner(t *testing.T) {
 		NoError(t, err)
 	}
 
-	expectedSource := LoadAndInterpolate(t, filepath.Join("sketch2", "SketchWithIfDef.resolved.directives.txt"), context)
+	bytes, err1 := ioutil.ReadFile(filepath.Join("sketch2", "SketchWithIfDef.resolved.directives.txt"))
+	NoError(t, err1)
+	expectedSource := string(bytes)
+
 	require.Equal(t, expectedSource, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 
 }

--- a/src/arduino.cc/builder/test/helper.go
+++ b/src/arduino.cc/builder/test/helper.go
@@ -38,20 +38,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
-	"text/template"
-	"bytes"
 )
-
-func LoadAndInterpolate(t *testing.T, filename string, context map[string]interface{}) string {
-	tpl, err := template.ParseFiles(filename)
-	NoError(t, err)
-
-	var buf bytes.Buffer
-	err = tpl.Execute(&buf, context)
-	NoError(t, err)
-
-	return buf.String()
-}
 
 func Abs(t *testing.T, rel string) string {
 	toolPath, err := filepath.Abs(rel)

--- a/src/arduino.cc/builder/test/prototypes_adder_test.go
+++ b/src/arduino.cc/builder/test/prototypes_adder_test.go
@@ -34,6 +34,7 @@ import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
 	"github.com/stretchr/testify/require"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -116,7 +117,11 @@ func TestPrototypesAdderSketchWithIfDef(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch2", "SketchWithIfDef.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch2", "SketchWithIfDef.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -156,7 +161,11 @@ func TestPrototypesAdderBaladuino(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch3", "Baladuino.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch3", "Baladuino.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -196,7 +205,11 @@ func TestPrototypesAdderCharWithEscapedDoubleQuote(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch4", "CharWithEscapedDoubleQuote.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch4", "CharWithEscapedDoubleQuote.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -236,7 +249,11 @@ func TestPrototypesAdderIncludeBetweenMultilineComment(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch5", "IncludeBetweenMultilineComment.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch5", "IncludeBetweenMultilineComment.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -276,7 +293,11 @@ func TestPrototypesAdderLineContinuations(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch6", "LineContinuations.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch6", "LineContinuations.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -316,7 +337,11 @@ func TestPrototypesAdderStringWithComment(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch7", "StringWithComment.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch7", "StringWithComment.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -356,7 +381,11 @@ func TestPrototypesAdderSketchWithStruct(t *testing.T) {
 		NoError(t, err)
 	}
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch8", "SketchWithStruct.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch8", "SketchWithStruct.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -399,7 +428,11 @@ func TestPrototypesAdderSketchWithConfig(t *testing.T) {
 	require.Equal(t, "#include <Arduino.h>\n#line 1\n", context[constants.CTX_INCLUDE_SECTION].(string))
 	require.Equal(t, "void setup();\nvoid loop();\n#line 13\n", context[constants.CTX_PROTOTYPE_SECTION].(string))
 
-	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch_with_config", "sketch_with_config.preprocessed.txt"), context)
+	bytes, err := ioutil.ReadFile(filepath.Join("sketch_with_config", "sketch_with_config.preprocessed.txt"))
+	NoError(t, err)
+
+	preprocessed := string(bytes)
+
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 

--- a/src/arduino.cc/builder/test/sketch1/merged_sketch.txt
+++ b/src/arduino.cc/builder/test/sketch1/merged_sketch.txt
@@ -1,4 +1,4 @@
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "sketch.ino"
 void setup() {
 
 }
@@ -6,9 +6,9 @@ void setup() {
 void loop() {
 
 }
-#line 1 "{{(index .sketch.OtherSketchFiles 0).Name}}"
+#line 1 "old.pde"
 
-#line 1 "{{(index .sketch.OtherSketchFiles 1).Name}}"
+#line 1 "other.ino"
 String hello() {
   return "world";
 }

--- a/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "SketchWithIfDef.ino"
 #define DEBUG 1
 #define DISABLED 0
 

--- a/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.resolved.directives.txt
+++ b/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.resolved.directives.txt
@@ -1,4 +1,4 @@
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "SketchWithIfDef.ino"
 #define DEBUG 1
 #define DISABLED 0
 

--- a/src/arduino.cc/builder/test/sketch3/Baladuino.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch3/Baladuino.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "Baladuino.ino"
 /*
  * The code is released under the GNU General Public License.
  * Developed by Kristian Lauszus, TKJ Electronics 2013

--- a/src/arduino.cc/builder/test/sketch4/CharWithEscapedDoubleQuote.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch4/CharWithEscapedDoubleQuote.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "CharWithEscapedDoubleQuote.ino"
 #include <SoftwareSerial.h> // required to send and receive AT commands from the GPRS Shield
 #include <Wire.h> // required for I2C communication with the RTC
 

--- a/src/arduino.cc/builder/test/sketch5/IncludeBetweenMultilineComment.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch5/IncludeBetweenMultilineComment.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "IncludeBetweenMultilineComment.ino"
 #include <CapacitiveSensor.h>
 /*
 #include <WiFi.h>

--- a/src/arduino.cc/builder/test/sketch6/LineContinuations.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch6/LineContinuations.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "LineContinuations.ino"
 const char *foo = "\
 hello \
 world\n";

--- a/src/arduino.cc/builder/test/sketch7/StringWithComment.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch7/StringWithComment.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "StringWithComment.ino"
 void setup();
 void loop();
 #line 1

--- a/src/arduino.cc/builder/test/sketch8/SketchWithStruct.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch8/SketchWithStruct.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "SketchWithStruct.ino"
 /* START CODE */
 
 struct A_NEW_TYPE {

--- a/src/arduino.cc/builder/test/sketch_source_merger_test.go
+++ b/src/arduino.cc/builder/test/sketch_source_merger_test.go
@@ -34,11 +34,11 @@ import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
 	"github.com/stretchr/testify/require"
+	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
 )
-
 
 func TestMergeSketch(t *testing.T) {
 	context := make(map[string]interface{})
@@ -57,6 +57,9 @@ func TestMergeSketch(t *testing.T) {
 
 	source := context[constants.CTX_SOURCE].(string)
 
-	expected_source := LoadAndInterpolate(t, filepath.Join("sketch1", "merged_sketch.txt"), context)
+	bytes, err1 := ioutil.ReadFile(filepath.Join("sketch1", "merged_sketch.txt"))
+	NoError(t, err1)
+
+	expected_source := string(bytes)
 	require.Equal(t, expected_source, strings.Replace(source, "\r\n", "\n", -1))
 }

--- a/src/arduino.cc/builder/test/sketch_with_config/sketch_with_config.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch_with_config/sketch_with_config.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "{{.sketch.MainFile.Name}}"
+#line 1 "sketch_with_config.ino"
 #include "config.h"
 
 #ifdef DEBUG


### PR DESCRIPTION
Reverts arduino/arduino-builder#9