### PR TITLE
Use absolute paths in #line directives generated

### DIFF
--- a/src/arduino.cc/builder/sketch_source_merger.go
+++ b/src/arduino.cc/builder/sketch_source_merger.go
@@ -32,7 +32,6 @@ package builder
 import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
-	"path/filepath"
 )
 
 type SketchSourceMerger struct{}
@@ -52,7 +51,7 @@ func (s *SketchSourceMerger) Run(context map[string]interface{}) error {
 }
 
 func addPreprocLine(sketch *types.SketchFile) string {
-	source := "#line 1 \"" + filepath.Base(sketch.Name) + "\"\n"
+	source := "#line 1 \"" + sketch.Name + "\"\n"
 	source += sketch.Source
 	source += "\n"
 

--- a/src/arduino.cc/builder/test/coan_runner_test.go
+++ b/src/arduino.cc/builder/test/coan_runner_test.go
@@ -34,7 +34,6 @@ import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,10 +67,7 @@ func TestCoanRunner(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err1 := ioutil.ReadFile(filepath.Join("sketch2", "SketchWithIfDef.resolved.directives.txt"))
-	NoError(t, err1)
-	expectedSource := string(bytes)
-
+	expectedSource := LoadAndInterpolate(t, filepath.Join("sketch2", "SketchWithIfDef.resolved.directives.txt"), context)
 	require.Equal(t, expectedSource, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 
 }

--- a/src/arduino.cc/builder/test/helper.go
+++ b/src/arduino.cc/builder/test/helper.go
@@ -38,7 +38,20 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"testing"
+	"text/template"
+	"bytes"
 )
+
+func LoadAndInterpolate(t *testing.T, filename string, context map[string]interface{}) string {
+	tpl, err := template.ParseFiles(filename)
+	NoError(t, err)
+
+	var buf bytes.Buffer
+	err = tpl.Execute(&buf, context)
+	NoError(t, err)
+
+	return buf.String()
+}
 
 func Abs(t *testing.T, rel string) string {
 	toolPath, err := filepath.Abs(rel)

--- a/src/arduino.cc/builder/test/prototypes_adder_test.go
+++ b/src/arduino.cc/builder/test/prototypes_adder_test.go
@@ -34,7 +34,6 @@ import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,11 +116,7 @@ func TestPrototypesAdderSketchWithIfDef(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch2", "SketchWithIfDef.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch2", "SketchWithIfDef.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -161,11 +156,7 @@ func TestPrototypesAdderBaladuino(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch3", "Baladuino.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch3", "Baladuino.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -205,11 +196,7 @@ func TestPrototypesAdderCharWithEscapedDoubleQuote(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch4", "CharWithEscapedDoubleQuote.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch4", "CharWithEscapedDoubleQuote.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -249,11 +236,7 @@ func TestPrototypesAdderIncludeBetweenMultilineComment(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch5", "IncludeBetweenMultilineComment.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch5", "IncludeBetweenMultilineComment.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -293,11 +276,7 @@ func TestPrototypesAdderLineContinuations(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch6", "LineContinuations.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch6", "LineContinuations.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -337,11 +316,7 @@ func TestPrototypesAdderStringWithComment(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch7", "StringWithComment.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch7", "StringWithComment.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -381,11 +356,7 @@ func TestPrototypesAdderSketchWithStruct(t *testing.T) {
 		NoError(t, err)
 	}
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch8", "SketchWithStruct.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch8", "SketchWithStruct.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 
@@ -428,11 +399,7 @@ func TestPrototypesAdderSketchWithConfig(t *testing.T) {
 	require.Equal(t, "#include <Arduino.h>\n#line 1\n", context[constants.CTX_INCLUDE_SECTION].(string))
 	require.Equal(t, "void setup();\nvoid loop();\n#line 13\n", context[constants.CTX_PROTOTYPE_SECTION].(string))
 
-	bytes, err := ioutil.ReadFile(filepath.Join("sketch_with_config", "sketch_with_config.preprocessed.txt"))
-	NoError(t, err)
-
-	preprocessed := string(bytes)
-
+	preprocessed := LoadAndInterpolate(t, filepath.Join("sketch_with_config", "sketch_with_config.preprocessed.txt"), context)
 	require.Equal(t, preprocessed, strings.Replace(context[constants.CTX_SOURCE].(string), "\r\n", "\n", -1))
 }
 

--- a/src/arduino.cc/builder/test/sketch1/merged_sketch.txt
+++ b/src/arduino.cc/builder/test/sketch1/merged_sketch.txt
@@ -1,4 +1,4 @@
-#line 1 "sketch.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 void setup() {
 
 }
@@ -6,9 +6,9 @@ void setup() {
 void loop() {
 
 }
-#line 1 "old.pde"
+#line 1 "{{(index .sketch.OtherSketchFiles 0).Name}}"
 
-#line 1 "other.ino"
+#line 1 "{{(index .sketch.OtherSketchFiles 1).Name}}"
 String hello() {
   return "world";
 }

--- a/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "SketchWithIfDef.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 #define DEBUG 1
 #define DISABLED 0
 

--- a/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.resolved.directives.txt
+++ b/src/arduino.cc/builder/test/sketch2/SketchWithIfDef.resolved.directives.txt
@@ -1,4 +1,4 @@
-#line 1 "SketchWithIfDef.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 #define DEBUG 1
 #define DISABLED 0
 

--- a/src/arduino.cc/builder/test/sketch3/Baladuino.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch3/Baladuino.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "Baladuino.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 /*
  * The code is released under the GNU General Public License.
  * Developed by Kristian Lauszus, TKJ Electronics 2013

--- a/src/arduino.cc/builder/test/sketch4/CharWithEscapedDoubleQuote.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch4/CharWithEscapedDoubleQuote.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "CharWithEscapedDoubleQuote.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 #include <SoftwareSerial.h> // required to send and receive AT commands from the GPRS Shield
 #include <Wire.h> // required for I2C communication with the RTC
 

--- a/src/arduino.cc/builder/test/sketch5/IncludeBetweenMultilineComment.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch5/IncludeBetweenMultilineComment.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "IncludeBetweenMultilineComment.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 #include <CapacitiveSensor.h>
 /*
 #include <WiFi.h>

--- a/src/arduino.cc/builder/test/sketch6/LineContinuations.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch6/LineContinuations.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "LineContinuations.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 const char *foo = "\
 hello \
 world\n";

--- a/src/arduino.cc/builder/test/sketch7/StringWithComment.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch7/StringWithComment.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "StringWithComment.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 void setup();
 void loop();
 #line 1

--- a/src/arduino.cc/builder/test/sketch8/SketchWithStruct.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch8/SketchWithStruct.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "SketchWithStruct.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 /* START CODE */
 
 struct A_NEW_TYPE {

--- a/src/arduino.cc/builder/test/sketch_source_merger_test.go
+++ b/src/arduino.cc/builder/test/sketch_source_merger_test.go
@@ -34,11 +34,11 @@ import (
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/types"
 	"github.com/stretchr/testify/require"
-	"io/ioutil"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
 
 func TestMergeSketch(t *testing.T) {
 	context := make(map[string]interface{})
@@ -57,9 +57,6 @@ func TestMergeSketch(t *testing.T) {
 
 	source := context[constants.CTX_SOURCE].(string)
 
-	bytes, err1 := ioutil.ReadFile(filepath.Join("sketch1", "merged_sketch.txt"))
-	NoError(t, err1)
-
-	expected_source := string(bytes)
+	expected_source := LoadAndInterpolate(t, filepath.Join("sketch1", "merged_sketch.txt"), context)
 	require.Equal(t, expected_source, strings.Replace(source, "\r\n", "\n", -1))
 }

--- a/src/arduino.cc/builder/test/sketch_with_config/sketch_with_config.preprocessed.txt
+++ b/src/arduino.cc/builder/test/sketch_with_config/sketch_with_config.preprocessed.txt
@@ -1,6 +1,6 @@
 #include <Arduino.h>
 #line 1
-#line 1 "sketch_with_config.ino"
+#line 1 "{{.sketch.MainFile.Name}}"
 #include "config.h"
 
 #ifdef DEBUG


### PR DESCRIPTION
Multiple .ino files in a sketch are concatenated together, adding #line
directives so error messages refer to the original filenames. However,
these directives used plain filenames, without a path. Since these
filenames end up in the debug info as-is, this complicates using a
debugger on the resulting .elf file. Using full pathnames fixes this.

The tests are updated to expect full paths as well. This uses the
text/template package to process the sketch file, allowing it access to
the full context. This is a bit overkill, but it is easy and might be
useful for more complex testcases later.

This fixes arduino/Arduino#3746.

Signed-off-by: Matthijs Kooijman <matthijs@stdin.nl>