### PR TITLE
Add Mercurial dependency information in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ See [Doing continuous integration with arduino builder](https://github.com/ardui
 
 You need [Go 1.4.3](https://golang.org/dl/#go1.4.3).
 
-Repo root contains script `setup_go_env_vars`. Use it as is or as a template for setting up Go environment variables.
+Repo root contains the script `setup_go_env_vars`. Use it as is or as a template for setting up Go environment variables.
+
+To install `codereview/patch` you have to install [Mercurial](https://www.mercurial-scm.org/) first.
 
 Once done, run the following commands:
 


### PR DESCRIPTION
We had some issues installing the dependencies because the Mercurial dependency wasn't specified.

Signed-off-by: Matteo Giaccone <matteo.giaccone@vitsoe.com>