### PR TITLE
Use standard Golang folder structure

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ import (
 	"github.com/go-errors/errors"
 )
 
-const VERSION = "1.3.14"
+const VERSION = "1.3.15"
 
 const FLAG_ACTION_COMPILE = "compile"
 const FLAG_ACTION_PREPROCESS = "preprocess"


### PR DESCRIPTION
rebases #113 and supersedes it, modifying the README to take advantage of the new folder structure