### PR TITLE
One way to handle multi-line prototypes in arduino files

### DIFF
--- a/src/arduino.cc/builder/ctags/ctags_parser.go
+++ b/src/arduino.cc/builder/ctags/ctags_parser.go
@@ -38,6 +38,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"bufio"
 )
 
 const KIND_PROTOTYPE = "prototype"
@@ -154,6 +155,35 @@ func prototypeAndCodeDontMatch(tag *types.CTag) bool {
 	}
 
 	code := removeSpacesAndTabs(tag.Code)
+
+	// original code is multi-line, which tags doesn't have - could we find this code in the
+	// original source file, for purposes of checking here?
+	if strings.Index(code, ")") == -1 {
+		file, err := os.Open(tag.Filename)
+		if err == nil {
+			defer file.Close()
+
+			scanner := bufio.NewScanner(file)
+			line := 1
+
+			// skip lines until we get to the start of this tag
+			for scanner.Scan() && line < tag.Line {
+				line++;
+			}
+
+			// read up to 10 lines in search of a closing paren
+			newcode := scanner.Text()
+			for scanner.Scan() && line < (tag.Line + 10) && strings.Index(newcode, ")") == -1 {
+				newcode += scanner.Text()
+			}
+
+			// don't bother replacing the code text if we haven't found a closing paren
+			if strings.Index(newcode, ")") != -1 {
+				code = removeSpacesAndTabs(newcode)
+			}
+		}
+	}
+
 	prototype := removeSpacesAndTabs(tag.Prototype)
 	prototype = removeTralingSemicolon(prototype)
 

--- a/src/arduino.cc/builder/test/sketch_with_multiline_prototypes/sketch_with_multiline_prototypes.ino
+++ b/src/arduino.cc/builder/test/sketch_with_multiline_prototypes/sketch_with_multiline_prototypes.ino
@@ -1,0 +1,8 @@
+void setup() { myctagstestfunc(1,2,3,4); }
+
+void myctagstestfunc(int a,
+int b,
+int c,
+int d) { }
+
+void loop() {}

--- a/src/arduino.cc/builder/test/try_build_of_problematic_sketch_test.go
+++ b/src/arduino.cc/builder/test/try_build_of_problematic_sketch_test.go
@@ -185,6 +185,10 @@ func TestTryBuild035(t *testing.T) {
 	tryBuild(t, "sketch_with_enum_class", "sketch_with_enum_class.ino")
 }
 
+func TestTryBuild036(t *testing.T) { 
+	tryBuild(t, "sketch_with_multiline_prototypes", "sketch_with_multiline_prototypes.ino")
+}
+
 func makeDefaultContext(t *testing.T) map[string]interface{} {
 	DownloadCoresAndToolsAndLibraries(t)
 


### PR DESCRIPTION
A somewhat heavy handed way to deal with arduino/arduino-builder#80  if we detect that the code for a tag is multiline (that is, there's no closing paren), use the Filename/Line info in the tag to attempt to read a few lines from the original code to hopefully get a better block of code to look for the prototype in.