### PR TITLE
Add test for templates containing shifts

### DIFF
--- a/src/arduino.cc/builder/test/ctags_runner_test.go
+++ b/src/arduino.cc/builder/test/ctags_runner_test.go
@@ -271,7 +271,7 @@ func TestCTagsRunnerSketchWithTemplates(t *testing.T) {
 	}
 
 	sketchLocation = strings.Replace(sketchLocation, "\\", "\\\\", -1)
-	expectedOutput := "printGyro\t" + sketchLocation + "\t/^void printGyro()$/;\"\tkind:function\tline:8\tsignature:()\treturntype:void\n"
+	expectedOutput := "printGyro\t" + sketchLocation + "\t/^void printGyro()$/;\"\tkind:function\tline:10\tsignature:()\treturntype:void\n"
 
 	require.Equal(t, expectedOutput, strings.Replace(context[constants.CTX_CTAGS_OUTPUT].(string), "\r\n", "\n", -1))
 }

--- a/src/arduino.cc/builder/test/ctags_runner_test.go
+++ b/src/arduino.cc/builder/test/ctags_runner_test.go
@@ -231,3 +231,47 @@ func TestCTagsRunnerSketchWithNamespace(t *testing.T) {
 
 	require.Equal(t, expectedOutput, strings.Replace(context[constants.CTX_CTAGS_OUTPUT].(string), "\r\n", "\n", -1))
 }
+
+func TestCTagsRunnerSketchWithTemplates(t *testing.T) {
+	DownloadCoresAndToolsAndLibraries(t)
+
+	context := make(map[string]interface{})
+
+	buildPath := SetupBuildPath(t, context)
+	defer os.RemoveAll(buildPath)
+
+	sketchLocation := Abs(t, filepath.Join("sketch_with_templates_and_shift", "template_and_shift.cpp"))
+	context[constants.CTX_HARDWARE_FOLDERS] = []string{filepath.Join("..", "hardware"), "hardware", "downloaded_hardware"}
+	context[constants.CTX_TOOLS_FOLDERS] = []string{"downloaded_tools"}
+	context[constants.CTX_FQBN] = "arduino:avr:leonardo"
+	context[constants.CTX_SKETCH_LOCATION] = sketchLocation
+	context[constants.CTX_BUILD_PROPERTIES_RUNTIME_IDE_VERSION] = "10600"
+	context[constants.CTX_BUILT_IN_LIBRARIES_FOLDERS] = []string{"downloaded_libraries"}
+	context[constants.CTX_OTHER_LIBRARIES_FOLDERS] = []string{"libraries"}
+	context[constants.CTX_VERBOSE] = true
+
+	commands := []types.Command{
+		&builder.SetupHumanLoggerIfMissing{},
+
+		&builder.ContainerSetupHardwareToolsLibsSketchAndProps{},
+
+		&builder.ContainerMergeCopySketchFiles{},
+
+		&builder.ContainerFindIncludes{},
+
+		&builder.PrintUsedLibrariesIfVerbose{},
+		&builder.WarnAboutArchIncompatibleLibraries{},
+		&builder.CTagsTargetFileSaver{SourceField: constants.CTX_SOURCE, TargetFileName: constants.FILE_CTAGS_TARGET},
+		&ctags.CTagsRunner{},
+	}
+
+	for _, command := range commands {
+		err := command.Run(context)
+		NoError(t, err)
+	}
+
+	sketchLocation = strings.Replace(sketchLocation, "\\", "\\\\", -1)
+	expectedOutput := "printGyro\t" + sketchLocation + "\t/^void printGyro()$/;\"\tkind:function\tline:8\tsignature:()\treturntype:void\n"
+
+	require.Equal(t, expectedOutput, strings.Replace(context[constants.CTX_CTAGS_OUTPUT].(string), "\r\n", "\n", -1))
+}

--- a/src/arduino.cc/builder/test/helper_tools_downloader.go
+++ b/src/arduino.cc/builder/test/helper_tools_downloader.go
@@ -138,6 +138,7 @@ func DownloadCoresAndToolsAndLibraries(t *testing.T) {
 		Library{Name: "CapacitiveSensor", Version: "0.5.0", VersionInLibProperties: "0.5"},
 		Library{Name: "Ethernet", Version: "1.1.1"},
 		Library{Name: "Robot IR Remote", Version: "1.0.2"},
+		Library{Name: "FastLED", Version: "3.1.0"},
 	}
 
 	download(t, cores, boardsManagerCores, boardsManagerRedBearCores, tools, toolsMultipleVersions, boardsManagerTools, boardsManagerRFduinoTools, libraries)

--- a/src/arduino.cc/builder/test/sketch11/sketch_fastleds.ino
+++ b/src/arduino.cc/builder/test/sketch11/sketch_fastleds.ino
@@ -1,0 +1,27 @@
+#include "FastLED.h"
+
+#define DATA_PIN    7
+#define CLK_PIN   6
+#define LED_TYPE    APA102
+#define COLOR_ORDER GRB
+#define NUM_LEDS    79
+CRGB leds[NUM_LEDS];
+
+#define BRIGHTNESS          96
+#define FRAMES_PER_SECOND  120
+void setup() {
+
+  FastLED.addLeds<LED_TYPE, DATA_PIN, CLK_PIN, COLOR_ORDER>(leds, NUM_LEDS).setCorrection(TypicalLEDStrip);
+}
+
+void loop() {
+
+}
+
+typedef void (*SimplePatternList[])();
+//SimplePatternList gPatterns = { rainbow, rainbowWithGlitter, confetti, sinelon, juggle, bpm };
+SimplePatternList gPatterns = {sinelon};
+
+void sinelon()
+{
+}

--- a/src/arduino.cc/builder/test/sketch_with_templates_and_shift/template_and_shift.cpp
+++ b/src/arduino.cc/builder/test/sketch_with_templates_and_shift/template_and_shift.cpp
@@ -1,5 +1,7 @@
 template<> class FastPin<0> : public _ARMPIN<0, 10, 1 << 10, 0> {};; 
 
+template<> class FastPin<0> : public _ARMPIN<0, 10, 1 < 10, 0> {};; 
+
 template <class SomeType, template <class> class OtherType> class NestedTemplateClass
 {
   OtherType<SomeType> f;

--- a/src/arduino.cc/builder/test/sketch_with_templates_and_shift/template_and_shift.cpp
+++ b/src/arduino.cc/builder/test/sketch_with_templates_and_shift/template_and_shift.cpp
@@ -1,0 +1,10 @@
+template<> class FastPin<0> : public _ARMPIN<0, 10, 1 << 10, 0> {};; 
+
+template <class SomeType, template <class> class OtherType> class NestedTemplateClass
+{
+  OtherType<SomeType> f;
+};
+
+void printGyro()
+{
+}

--- a/src/arduino.cc/builder/test/try_build_of_problematic_sketch_test.go
+++ b/src/arduino.cc/builder/test/try_build_of_problematic_sketch_test.go
@@ -185,6 +185,12 @@ func TestTryBuild035(t *testing.T) {
 	tryBuild(t, "sketch_with_enum_class", "sketch_with_enum_class.ino")
 }
 
+func TestTryBuild036(t *testing.T) {
+	context := makeDefaultContext(t)
+	context[constants.CTX_FQBN] = "arduino:samd:arduino_zero_native"
+	tryBuildWithContext(t, context, "sketch11", "sketch_fastleds.ino")
+}
+
 func makeDefaultContext(t *testing.T) map[string]interface{} {
 	DownloadCoresAndToolsAndLibraries(t)
 


### PR DESCRIPTION
Ctags is failing badly with this case (encountered on FastLeds, `samd` architecture)