### PR TITLE
Use CPP recipe to generate PREPROC if empty

### DIFF
--- a/src/arduino.cc/builder/hardware/platform.txt
+++ b/src/arduino.cc/builder/hardware/platform.txt
@@ -8,9 +8,9 @@ tools.ctags.pattern="{cmd.path}" -u --language-force=c++ -f - --c++-kinds=svpf -
 tools.avrdude.path={runtime.tools.avrdude.path}
 
 preproc.includes.flags=-w -x c++ -M -MG -MP
-preproc.includes.compatibility_flags={build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {compiler.libsam.c.flags} {compiler.arm.cmsis.path} {build.variant_system_include}
-recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {preproc.includes.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {preproc.includes.compatibility_flags} {includes} "{source_file}"
+#preproc.includes.compatibility_flags={build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {compiler.libsam.c.flags} {compiler.arm.cmsis.path} {build.variant_system_include}
+#recipe.preproc.includes="{compiler.path}{compiler.cpp.cmd}" {preproc.includes.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {preproc.includes.compatibility_flags} {includes} "{source_file}"
 
 preproc.macros.flags=-w -x c++ -E -CC
-preproc.macros.compatibility_flags={build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {compiler.libsam.c.flags} {compiler.arm.cmsis.path} {build.variant_system_include}
-recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpreprocessor.flags} {compiler.cpp.flags} {preproc.macros.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {preproc.macros.compatibility_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"
+#preproc.macros.compatibility_flags={build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {compiler.libsam.c.flags} {compiler.arm.cmsis.path} {build.variant_system_include}
+#recipe.preproc.macros="{compiler.path}{compiler.cpp.cmd}" {compiler.cpreprocessor.flags} {compiler.cpp.flags} {preproc.macros.flags} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {preproc.macros.compatibility_flags} {includes} "{source_file}" -o "{preprocessed_file_path}"

--- a/src/arduino.cc/builder/includes_finder_with_gcc.go
+++ b/src/arduino.cc/builder/includes_finder_with_gcc.go
@@ -62,6 +62,11 @@ func (s *IncludesFinderWithGCC) Run(context map[string]interface{}) error {
 	properties[constants.BUILD_PROPERTIES_INCLUDES] = includesParams
 	builder_utils.RemoveHyphenMDDFlagFromGCCCommandLine(properties)
 
+	if properties[constants.RECIPE_PREPROC_INCLUDES] == "" {
+		//generate RECIPE_PREPROC_INCLUDES from RECIPE_CPP_PATTERN
+		properties[constants.RECIPE_PREPROC_INCLUDES] = GeneratePreprocIncludePatternFromCompile(properties[constants.RECIPE_CPP_PATTERN])
+	}
+
 	output, err := builder_utils.ExecRecipe(properties, constants.RECIPE_PREPROC_INCLUDES, true, verbose, false, logger)
 	if err != nil {
 		return utils.WrapError(err)
@@ -70,4 +75,13 @@ func (s *IncludesFinderWithGCC) Run(context map[string]interface{}) error {
 	context[constants.CTX_GCC_MINUS_M_OUTPUT] = string(output)
 
 	return nil
+}
+
+func GeneratePreprocIncludePatternFromCompile(compilePattern string) string {
+	// add {preproc.includes.flags}
+	// remove -o "{object_file}"
+	returnString := compilePattern
+	returnString = strings.Replace(returnString, "{compiler.cpp.flags}", "{compiler.cpp.flags} {preproc.includes.flags}", 1)
+	returnString = strings.Replace(returnString, "-o {object_file}", "", 1)
+	return returnString
 }

--- a/src/arduino.cc/builder/test/hardware_loader_test.go
+++ b/src/arduino.cc/builder/test/hardware_loader_test.go
@@ -147,7 +147,6 @@ func TestLoadHardwareMixingUserHardwareFolder(t *testing.T) {
 	require.Equal(t, "\"{cmd.path}\" -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives \"{source_file}\"", packages.Properties["tools.ctags.pattern"])
 	require.Equal(t, "{runtime.tools.avrdude.path}", packages.Properties["tools.avrdude.path"])
 	require.Equal(t, "-w -x c++ -E -CC", packages.Properties["preproc.macros.flags"])
-	require.Equal(t, "{build.mbed_api_include} {build.nRF51822_api_include} {build.ble_api_include} {compiler.libsam.c.flags} {compiler.arm.cmsis.path} {build.variant_system_include}", packages.Properties["preproc.macros.compatibility_flags"])
 
 	if runtime.GOOS != "windows" {
 		require.NotNil(t, packages.Packages["my_symlinked_avr_platform"])


### PR DESCRIPTION
Since the `preproc` rule is nothing more than the `cpp` rule with some extra flags and a different target, generate it instead than manually compiling a list of "compatibility_flags" and relying on it

solves #106
@matthijskooijman 