### PR TITLE
Fix ` extern "C" ` prototype generation

### DIFF
--- a/src/arduino.cc/builder/ctags/ctags_parser.go
+++ b/src/arduino.cc/builder/ctags/ctags_parser.go
@@ -47,6 +47,7 @@ const KIND_FUNCTION = "function"
 
 const TEMPLATE = "template"
 const STATIC = "static"
+const EXTERN = "extern \"C\""
 
 var KNOWN_TAG_KINDS = map[string]bool{
 	"prototype": true,
@@ -100,6 +101,9 @@ func addPrototype(tag *types.CTag) {
 	tag.PrototypeModifiers = ""
 	if strings.Index(tag.Code, STATIC+" ") != -1 {
 		tag.PrototypeModifiers = tag.PrototypeModifiers + " " + STATIC
+	}
+	if strings.Index(tag.Code, EXTERN+" ") != -1 {
+		tag.PrototypeModifiers = tag.PrototypeModifiers + " " + EXTERN
 	}
 	tag.PrototypeModifiers = strings.TrimSpace(tag.PrototypeModifiers)
 }

--- a/src/arduino.cc/builder/test/sketch_with_externC/sketch_with_externC.ino
+++ b/src/arduino.cc/builder/test/sketch_with_externC/sketch_with_externC.ino
@@ -1,0 +1,11 @@
+void setup() {
+  // put your setup code here, to run once:
+  test();
+}
+
+void loop() {
+  // put your main code here, to run repeatedly:
+
+}
+
+extern "C" void test() {}

--- a/src/arduino.cc/builder/test/try_build_of_problematic_sketch_test.go
+++ b/src/arduino.cc/builder/test/try_build_of_problematic_sketch_test.go
@@ -191,6 +191,10 @@ func TestTryBuild036(t *testing.T) {
 	tryBuildWithContext(t, context, "sketch11", "sketch_fastleds.ino")
 }
 
+func TestTryBuild037(t *testing.T) {
+	tryBuild(t, "sketch_with_externC", "sketch_with_externC.ino")
+}
+
 func makeDefaultContext(t *testing.T) map[string]interface{} {
 	DownloadCoresAndToolsAndLibraries(t)
 


### PR DESCRIPTION
Adds `extern "C" ` as function modifier
Probably needs some testing for regressions (although the unit test are all passing)
Fixes #126 
@igrr 
[arduino-builder-pr128.zip](https://github.com/arduino/arduino-builder/files/176486/arduino-builder-pr128.zip)
