### PR TITLE
Don't wipe everything is only sketch path changed

### DIFF
--- a/src/arduino.cc/builder/wipeout_build_path_if_build_options_changed.go
+++ b/src/arduino.cc/builder/wipeout_build_path_if_build_options_changed.go
@@ -36,6 +36,7 @@ import (
 	"arduino.cc/builder/utils"
 	"os"
 	"path/filepath"
+	"regexp"
 )
 
 type WipeoutBuildPathIfBuildOptionsChanged struct{}
@@ -44,11 +45,19 @@ func (s *WipeoutBuildPathIfBuildOptionsChanged) Run(context map[string]interface
 	if !utils.MapHas(context, constants.CTX_BUILD_OPTIONS_PREVIOUS_JSON) {
 		return nil
 	}
-
 	buildOptionsJson := context[constants.CTX_BUILD_OPTIONS_JSON].(string)
 	previousBuildOptionsJson := context[constants.CTX_BUILD_OPTIONS_PREVIOUS_JSON].(string)
 	logger := context[constants.CTX_LOGGER].(i18n.Logger)
 
+	if buildOptionsJson == previousBuildOptionsJson {
+		return nil
+	}
+
+	re := regexp.MustCompile("(?m)^.*" + constants.CTX_SKETCH_LOCATION + ".*$[\r\n]+")
+	buildOptionsJson = re.ReplaceAllString(buildOptionsJson, "")
+	previousBuildOptionsJson = re.ReplaceAllString(previousBuildOptionsJson, "")
+
+	// if the only difference is the sketch path skip deleting everything
 	if buildOptionsJson == previousBuildOptionsJson {
 		return nil
 	}


### PR DESCRIPTION
If the environment variables are untouched but the sketch is saved automatically by the Java IDE (to another folder) the infamous "Build options changed" is triggered.
This commits adds a second check after removing the sketch location from the env variables, and skips the wipeout if the partial environments are equals

Should solve https://github.com/arduino/Arduino/issues/4713
@matthijskooijman @cmaglie @sandeepmistry @mbanzi 