### PR TITLE
Dependency parsing: if a file is not found trigger a full rebuild

### DIFF
--- a/src/arduino.cc/builder/builder_utils/utils.go
+++ b/src/arduino.cc/builder/builder_utils/utils.go
@@ -222,7 +222,9 @@ func ObjFileIsUpToDate(sourceFile, objectFile, dependencyFile string) (bool, err
 	for _, row := range rows {
 		depStat, err := os.Stat(row)
 		if err != nil && !os.IsNotExist(err) {
-			return false, i18n.WrapError(err)
+			// There is probably a parsing error of the dep file
+			// Ignore the error and trigger a full rebuild anyway
+			return false, nil
 		}
 		if os.IsNotExist(err) {
 			return false, nil


### PR DESCRIPTION
The missing file is probably due to a parsing error, better to trigger a rebuild in this case instead of exiting with an error. This is a quick workaround, the full solution is to properly parse .d files.

Fix #136