### PR TITLE
Do not full-rebuild if only sketch path changed.

### DIFF
--- a/src/arduino.cc/builder/props/properties.go
+++ b/src/arduino.cc/builder/props/properties.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-errors/errors"
 	"io/ioutil"
 	"os"
+	"reflect"
 	"regexp"
 	"runtime"
 	"strings"
@@ -168,6 +169,10 @@ func (aMap PropertiesMap) Clone() PropertiesMap {
 	newMap := make(PropertiesMap)
 	newMap.Merge(aMap)
 	return newMap
+}
+
+func (aMap PropertiesMap) Equals(anotherMap PropertiesMap) bool {
+	return reflect.DeepEqual(aMap, anotherMap)
 }
 
 func MergeMapsOfProperties(target map[string]PropertiesMap, sources ...map[string]PropertiesMap) map[string]PropertiesMap {

--- a/src/arduino.cc/builder/test/wipeout_build_path_if_build_options_changed_test.go
+++ b/src/arduino.cc/builder/test/wipeout_build_path_if_build_options_changed_test.go
@@ -46,8 +46,8 @@ func TestWipeoutBuildPathIfBuildOptionsChanged(t *testing.T) {
 	buildPath := SetupBuildPath(t, ctx)
 	defer os.RemoveAll(buildPath)
 
-	ctx.BuildOptionsJsonPrevious = "old"
-	ctx.BuildOptionsJson = "new"
+	ctx.BuildOptionsJsonPrevious = "{ \"old\":\"old\" }"
+	ctx.BuildOptionsJson = "{ \"new\":\"new\" }"
 
 	utils.TouchFile(filepath.Join(buildPath, "should_be_deleted.txt"))
 
@@ -77,7 +77,7 @@ func TestWipeoutBuildPathIfBuildOptionsChangedNoPreviousBuildOptions(t *testing.
 	buildPath := SetupBuildPath(t, ctx)
 	defer os.RemoveAll(buildPath)
 
-	ctx.BuildOptionsJson = "new"
+	ctx.BuildOptionsJson = "{ \"new\":\"new\" }"
 
 	utils.TouchFile(filepath.Join(buildPath, "should_not_be_deleted.txt"))
 
@@ -107,8 +107,8 @@ func TestWipeoutBuildPathIfBuildOptionsChangedBuildOptionsMatch(t *testing.T) {
 	buildPath := SetupBuildPath(t, ctx)
 	defer os.RemoveAll(buildPath)
 
-	ctx.BuildOptionsJsonPrevious = "options"
-	ctx.BuildOptionsJson = "options"
+	ctx.BuildOptionsJsonPrevious = "{ \"old\":\"old\" }"
+	ctx.BuildOptionsJson = "{ \"old\":\"old\" }"
 
 	utils.TouchFile(filepath.Join(buildPath, "should_not_be_deleted.txt"))
 


### PR DESCRIPTION
This commit fix two problems:

1) the sketch path is used as-is in a regexp: this causes troubles if the path contains regexp control chars like `[-]().\` etc.
2) the sketch is not fully rebuild if the only thing that changes is the sketch path.

this PR supersedes #135 