### PR TITLE
Improve include resolution fix for older compilers

### DIFF
--- a/src/arduino.cc/builder/includes_finder_with_regexp.go
+++ b/src/arduino.cc/builder/includes_finder_with_regexp.go
@@ -63,11 +63,13 @@ func (s *IncludesFinderWithRegExp) Run(ctx *types.Context) error {
 }
 
 func findIncludesForOldCompilers(source string) string {
-	firstLine := strings.Split(source, "\n")[0]
-	splittedLine := strings.Split(firstLine, ":")
-	for i, _ := range splittedLine {
-		if strings.Contains(splittedLine[i], "fatal error") {
-			return strings.TrimSpace(splittedLine[i+1])
+	lines := strings.Split(source, "\n")
+	for _, line := range lines {
+		splittedLine := strings.Split(line, ":")
+		for i, _ := range splittedLine {
+			if strings.Contains(splittedLine[i], "fatal error") {
+				return strings.TrimSpace(splittedLine[i+1])
+			}
 		}
 	}
 	return ""


### PR DESCRIPTION
The primary way to detect includes is to scan the compiler error output
for "#include" lines. However, older gcc versions did not print the
error line itself, only a message about the error, which would not be
detected. In bd5d3ec (Fix include resolution for older compilers), a
fallback was added to scan for "fatal error" followed by the missing
include filename, but that fallback only looked at the first line of the
error output.

When the missing #include line is not in the source file being compiled,
but in an included file, the error message would something like this:

	In file included from binouts.ino:52:0:
	regtable.h:31:22: fatal error: register.h: No such file or directory

So the filename that should be found is in the second line (or further).
This commit changes the fallback process to keep scanning lines of
compiler output, until one is found, instead of only looking at the
first line.

This fixes #97.

Signed-off-by: Matthijs Kooijman <matthijs@stdin.nl>