### PR TITLE
Add .github to the list of VCS folders

### DIFF
--- a/src/arduino.cc/builder/utils/utils.go
+++ b/src/arduino.cc/builder/utils/utils.go
@@ -146,7 +146,7 @@ func FilterFilesWithExtension(extension string) filterFiles {
 	}
 }
 
-var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".svn": true, ".hg": true, ".bzr": true}
+var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true}
 
 func IsSCCSOrHiddenFile(file os.FileInfo) bool {
 	return IsSCCSFile(file) || IsHiddenFile(file)


### PR DESCRIPTION
This prevents a warning when a library contains a .github folder, which
can contain some templates and other configuration for the github
platform.

Signed-off-by: Matthijs Kooijman <matthijs@stdin.nl>