### PR TITLE
Avoid breaking the build if broken symlinks found

### DIFF
--- a/src/arduino.cc/builder/gohasissues/go_has_issues.go
+++ b/src/arduino.cc/builder/gohasissues/go_has_issues.go
@@ -108,7 +108,8 @@ func ReadDir(dirname string) ([]os.FileInfo, error) {
 	for idx, info := range infos {
 		info, err := resolveSymlink(dirname, info)
 		if err != nil {
-			return nil, err
+			// unresolvable symlinks should be skipped silently
+			return nil, nil
 		}
 		infos[idx] = info
 	}


### PR DESCRIPTION
Fixes #159, please make sure that it doesn't introduce any regression
Tests are passing on Linux but something nasty could happen on different OS (or tests could be incomplete)