### PR TITLE
Fix UTF8 filenames not being matched by gcc -e output parsing

### DIFF
--- a/src/arduino.cc/builder/test/utils_test.go
+++ b/src/arduino.cc/builder/test/utils_test.go
@@ -127,4 +127,14 @@ func TestParseCppString(t *testing.T) {
 	require.Equal(t, true, ok)
 	require.Equal(t, ` !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_abcdefghijklmnopqrstuvwxyz{|}~`, str)
 	require.Equal(t, ``, rest)
+
+	str, rest, ok = utils.ParseCppString(`"/home/ççç/"`)
+	require.Equal(t, true, ok)
+	require.Equal(t, `/home/ççç/`, str)
+	require.Equal(t, ``, rest)
+
+	str, rest, ok = utils.ParseCppString(`"/home/ççç/ /$sdsdd\\"`)
+	require.Equal(t, true, ok)
+	require.Equal(t, `/home/ççç/ /$sdsdd\`, str)
+	require.Equal(t, ``, rest)
 }


### PR DESCRIPTION
Starting from https://github.com/arduino/arduino-builder/commit/81eadf324ef2f3d14034452bd40bd2f2eb75ff98, `ctags` is fed only with sketch code after the `gcc -e` pass.
If the filename contains non-ASCII characters, the string matching at https://github.com/arduino/arduino-builder/blob/master/src/arduino.cc/builder/filter_sketch_source.go#L59 returns `false` because `utils.ParseCppString` only treats ASCII strings.

This patch fixes this behaviour and adds some tests to demonstrate the functionality. All tests are passing.
