### PR TITLE
Fix prototype callback generation if direct reference is used

### DIFF
--- a/src/arduino.cc/builder/ctags/ctags_parser.go
+++ b/src/arduino.cc/builder/ctags/ctags_parser.go
@@ -236,7 +236,6 @@ func parseTag(row string) *types.CTag {
 
 	parts = parts[2:]
 
-	signature := ""
 	returntype := ""
 	for _, part := range parts {
 		if strings.Contains(part, ":") {
@@ -253,7 +252,7 @@ func parseTag(row string) *types.CTag {
 			case "typeref":
 				tag.Typeref = value
 			case "signature":
-				signature = value
+				tag.Signature = value
 			case "returntype":
 				returntype = value
 			case "class":
@@ -265,7 +264,7 @@ func parseTag(row string) *types.CTag {
 			}
 		}
 	}
-	tag.Prototype = returntype + " " + tag.FunctionName + signature + ";"
+	tag.Prototype = returntype + " " + tag.FunctionName + tag.Signature + ";"
 
 	if strings.Contains(row, "/^") && strings.Contains(row, "$/;") {
 		tag.Code = row[strings.Index(row, "/^")+2 : strings.Index(row, "$/;")]

--- a/src/arduino.cc/builder/ctags/ctags_to_prototypes.go
+++ b/src/arduino.cc/builder/ctags/ctags_to_prototypes.go
@@ -70,6 +70,9 @@ func functionNameUsedAsFunctionPointerIn(tag *types.CTag, functionNames []string
 		if strings.Index(tag.Code, "&"+functionName) != -1 {
 			return true
 		}
+		if strings.Index(tag.Code, functionName) != -1 {
+			return true
+		}
 	}
 	return false
 }

--- a/src/arduino.cc/builder/ctags/ctags_to_prototypes_test.go
+++ b/src/arduino.cc/builder/ctags/ctags_to_prototypes_test.go
@@ -209,6 +209,33 @@ func TestCTagsToPrototypesFunctionPointers(t *testing.T) {
 	require.Equal(t, 2, line)
 }
 
+func TestCTagsToPrototypesFunctionPointersNoIndirect(t *testing.T) {
+	ctx := &types.Context{}
+
+	bytes, err := ioutil.ReadFile(filepath.Join("ctags_output", "TestCTagsParserFunctionPointersNoIndirect.txt"))
+	NoError(t, err)
+
+	ctx.CTagsOutput = string(bytes)
+
+	commands := []types.Command{
+		&ctags.CTagsParser{},
+		&ctags.CTagsToPrototypes{},
+	}
+
+	for _, command := range commands {
+		err := command.Run(ctx)
+		NoError(t, err)
+	}
+
+	prototypes := ctx.Prototypes
+	require.Equal(t, 5, len(prototypes))
+	require.Equal(t, "void setup();", prototypes[0].Prototype)
+	require.Equal(t, "/tmp/test547238273/preproc/bug_callback.ino", prototypes[0].File)
+	require.Equal(t, "void loop();", prototypes[1].Prototype)
+
+	require.Equal(t, 10, ctx.PrototypesLineWhereToInsert)
+}
+
 func TestCTagsRunnerSketchWithClassFunction(t *testing.T) {
 	prototypes, _ := producePrototypes(t, "TestCTagsRunnerSketchWithClassFunction.txt")
 

--- a/src/arduino.cc/builder/ctags/test_data/TestCTagsParserFunctionPointersNoIndirect.txt
+++ b/src/arduino.cc/builder/ctags/test_data/TestCTagsParserFunctionPointersNoIndirect.txt
@@ -1,0 +1,7 @@
+BUG	/tmp/test547238273/preproc/bug_callback.ino	/^  public: BUG(void (*fn)(void)) {}$/;"	kind:function	line:6	class:BUG	signature:(void (*fn)(void))
+b	/tmp/test547238273/preproc/bug_callback.ino	/^BUG b(makeItBreak); \/\/this will break$/;"	kind:prototype	line:10	signature:(makeItBreak)returntype:BUG
+setup	/tmp/test547238273/preproc/bug_callback.ino	/^void setup() {$/;"	kind:function	line:12	signature:()	returntype:void
+loop	/tmp/test547238273/preproc/bug_callback.ino	/^void loop() {}$/;"	kind:function	line:16	signature:()	returntype:void
+makeItBreak	/tmp/test547238273/preproc/bug_callback.ino	/^void makeItBreak() {}$/;"	kind:function	line:18	signature:()	returntype:void
+caller	/tmp/test547238273/preproc/bug_callback.ino	/^void caller(int (*cc)(int ),int a) {$/;"	kind:function	line:20	signature:(int (*cc)(int ),int a)	returntype:void
+blub	/tmp/test547238273/preproc/bug_callback.ino	/^int blub(int a) {$/;"	kind:function	line:24	signature:(int a)	returntype:int

--- a/src/arduino.cc/builder/types/types.go
+++ b/src/arduino.cc/builder/types/types.go
@@ -252,6 +252,7 @@ type CTag struct {
 	Filename     string
 	Typeref      string
 	SkipMe       bool
+	Signature    string
 
 	Prototype          string
 	Function           string


### PR DESCRIPTION
Fixes  arduino/arduino-builder#180
Should be refactored when merging   arduino/arduino-builder#190