### PR TITLE
Fix UTF8 filenames not being matched by gcc -e output parsing (round 2)

### DIFF
--- a/src/arduino.cc/builder/test/utils_test.go
+++ b/src/arduino.cc/builder/test/utils_test.go
@@ -127,4 +127,14 @@ func TestParseCppString(t *testing.T) {
 	require.Equal(t, true, ok)
 	require.Equal(t, ` !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_abcdefghijklmnopqrstuvwxyz{|}~`, str)
 	require.Equal(t, ``, rest)
+
+	str, rest, ok = utils.ParseCppString(`"/home/ççç/"`)
+	require.Equal(t, true, ok)
+	require.Equal(t, `/home/ççç/`, str)
+	require.Equal(t, ``, rest)
+
+	str, rest, ok = utils.ParseCppString(`"/home/ççç/ /$sdsdd\\"`)
+	require.Equal(t, true, ok)
+	require.Equal(t, `/home/ççç/ /$sdsdd\`, str)
+	require.Equal(t, ``, rest)
 }

--- a/src/arduino.cc/builder/utils/utils.go
+++ b/src/arduino.cc/builder/utils/utils.go
@@ -38,6 +38,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"unicode/utf8"
 
 	"arduino.cc/builder/constants"
 	"arduino.cc/builder/gohasissues"
@@ -443,10 +444,12 @@ func ParseCppString(line string) (string, string, bool) {
 			return "", line, false
 		}
 
-		switch line[i] {
+		c, width := utf8.DecodeRuneInString(line[i:])
+
+		switch c {
 		// Backslash, next character is used unmodified
 		case '\\':
-			i++
+			i += width
 			if i >= len(line) {
 				return "", line, false
 			}
@@ -454,12 +457,12 @@ func ParseCppString(line string) (string, string, bool) {
 			break
 		// Quote, end of string
 		case '"':
-			return res, line[i+1:], true
+			return res, line[i+width:], true
 		default:
-			res += string(line[i])
+			res += string(c)
 			break
 		}
 
-		i++
+		i += width
 	}
 }


### PR DESCRIPTION
Supersedes #178 

/cc @facchinm 

