### PR TITLE
Don't forbid unknown files in a library

### DIFF
--- a/src/arduino.cc/builder/constants/constants.go
+++ b/src/arduino.cc/builder/constants/constants.go
@@ -192,7 +192,6 @@ const MSG_USING_CACHED_INCLUDES = "Using cached library dependencies for file: {
 const MSG_WARNING_LIB_INVALID_CATEGORY = "WARNING: Category '{0}' in library {1} is not valid. Setting to '{2}'"
 const MSG_WARNING_PLATFORM_MISSING_VALUE = "Warning: platform.txt from core '{0}' misses property '{1}', using default value '{2}'. Consider upgrading this core."
 const MSG_WARNING_PLATFORM_OLD_VALUES = "Warning: platform.txt from core '{0}' contains deprecated {1}, automatically converted to {2}. Consider upgrading this core."
-const MSG_WARNING_SPURIOUS_FILE_IN_LIB = "WARNING: Spurious {0} folder in '{1}' library"
 const MSG_WRONG_PROPERTIES_FILE = "Property line '{0}' in file {1} is invalid"
 const MSG_WRONG_PROPERTIES = "Property line '{0}' is invalid"
 const PACKAGE_NAME = "name"

--- a/src/arduino.cc/builder/libraries_loader.go
+++ b/src/arduino.cc/builder/libraries_loader.go
@@ -153,16 +153,6 @@ func makeNewLibrary(libraryFolder string, debugLevel int, logger i18n.Logger) (*
 		return nil, i18n.WrapError(err)
 	}
 
-	if debugLevel >= 0 {
-		for _, subFolder := range subFolders {
-			if utils.IsSCCSOrHiddenFile(subFolder) {
-				if !utils.IsSCCSFile(subFolder) && utils.IsHiddenFile(subFolder) {
-					logger.Fprintln(os.Stdout, constants.LOG_LEVEL_WARN, constants.MSG_WARNING_SPURIOUS_FILE_IN_LIB, filepath.Base(subFolder.Name()), libProperties[constants.LIBRARY_NAME])
-				}
-			}
-		}
-	}
-
 	if libProperties[constants.LIBRARY_ARCHITECTURES] == constants.EMPTY_STRING {
 		libProperties[constants.LIBRARY_ARCHITECTURES] = constants.LIBRARY_ALL_ARCHS
 	}

--- a/src/arduino.cc/builder/libraries_loader.go
+++ b/src/arduino.cc/builder/libraries_loader.go
@@ -148,11 +148,6 @@ func makeNewLibrary(libraryFolder string, debugLevel int, logger i18n.Logger) (*
 		addUtilityFolder(library)
 	}
 
-	subFolders, err := utils.ReadDirFiltered(libraryFolder, utils.FilterDirs)
-	if err != nil {
-		return nil, i18n.WrapError(err)
-	}
-
 	if libProperties[constants.LIBRARY_ARCHITECTURES] == constants.EMPTY_STRING {
 		libProperties[constants.LIBRARY_ARCHITECTURES] = constants.LIBRARY_ALL_ARCHS
 	}


### PR DESCRIPTION
Warning about unknown folders was considered bad in
https://github.com/arduino/Arduino/pull/1692
but the problem is still present in arduino-builder.

This has caused issues like
https://github.com/arduino/arduino-builder/issues/70#issuecomment-158994311
which resulted in
https://github.com/arduino/arduino-builder/pull/162

The original arguments in Arduino/pull/1692 still apply:
* It breaks forward compatibility if we later add more files or
  directories to the library format.
* It breaks for people who want to have some extra stuff in their
  library. We can't keep a list of "allowed" stuff, since there will always
  be stuff missing.

Signed-off-by: Mikael Falkvidd git@mjo.se <git@mjo.se>