### PR TITLE
Relax library matching rules when detecting libraries

### DIFF
--- a/src/arduino.cc/builder/resolve_library.go
+++ b/src/arduino.cc/builder/resolve_library.go
@@ -56,7 +56,6 @@ func ResolveLibrary(ctx *types.Context, header string) *types.Library {
 	}
 
 	if len(libraries) == 1 {
-		markImportedLibrary[libraries[0]] = true
 		return libraries[0]
 	}
 
@@ -92,7 +91,6 @@ func ResolveLibrary(ctx *types.Context, header string) *types.Library {
 
 	libraryResolutionResults[header] = types.LibraryResolutionResult{Library: library, NotUsedLibraries: filterOutLibraryFrom(libraries, library)}
 
-	markImportedLibrary[library] = true
 	return library
 }
 

--- a/src/arduino.cc/builder/resolve_library.go
+++ b/src/arduino.cc/builder/resolve_library.go
@@ -44,18 +44,13 @@ func ResolveLibrary(ctx *types.Context, header string) *types.Library {
 	libraryResolutionResults := ctx.LibrariesResolutionResults
 	importedLibraries := ctx.ImportedLibraries
 
-	markImportedLibrary := make(map[*types.Library]bool)
-	for _, library := range importedLibraries {
-		markImportedLibrary[library] = true
-	}
-
 	libraries := append([]*types.Library{}, headerToLibraries[header]...)
 
 	if libraries == nil || len(libraries) == 0 {
 		return nil
 	}
 
-	if markImportedLibraryContainsOneOfCandidates(markImportedLibrary, libraries) {
+	if importedLibraryContainsOneOfCandidates(importedLibraries, libraries) {
 		return nil
 	}
 
@@ -87,7 +82,7 @@ func ResolveLibrary(ctx *types.Context, header string) *types.Library {
 		library = libraries[0]
 	}
 
-	library = useAlreadyImportedLibraryWithSameNameIfExists(library, markImportedLibrary)
+	library = useAlreadyImportedLibraryWithSameNameIfExists(library, importedLibraries)
 
 	libraryResolutionResults[header] = types.LibraryResolutionResult{Library: library, NotUsedLibraries: filterOutLibraryFrom(libraries, library)}
 
@@ -101,10 +96,10 @@ func reverse(data []*types.Library) {
 	}
 }
 
-func markImportedLibraryContainsOneOfCandidates(markImportedLibrary map[*types.Library]bool, libraries []*types.Library) bool {
-	for markedLibrary, _ := range markImportedLibrary {
-		for _, library := range libraries {
-			if markedLibrary == library {
+func importedLibraryContainsOneOfCandidates(imported []*types.Library, candidates []*types.Library) bool {
+	for _, i := range imported {
+		for _, j := range candidates {
+			if i == j {
 				return true
 			}
 		}
@@ -112,8 +107,8 @@ func markImportedLibraryContainsOneOfCandidates(markImportedLibrary map[*types.L
 	return false
 }
 
-func useAlreadyImportedLibraryWithSameNameIfExists(library *types.Library, markImportedLibrary map[*types.Library]bool) *types.Library {
-	for lib, _ := range markImportedLibrary {
+func useAlreadyImportedLibraryWithSameNameIfExists(library *types.Library, imported []*types.Library) *types.Library {
+	for _, lib := range imported {
 		if lib.Name == library.Name {
 			return lib
 		}

--- a/src/arduino.cc/builder/resolve_library.go
+++ b/src/arduino.cc/builder/resolve_library.go
@@ -218,7 +218,7 @@ func findBestLibraryWithHeader(header string, libraries []*types.Library) *types
 
 func findLibWithName(name string, libraries []*types.Library) *types.Library {
 	for _, library := range libraries {
-		if library.Name == name {
+		if simplifyName(library.Name) == simplifyName(name) {
 			return library
 		}
 	}
@@ -227,7 +227,7 @@ func findLibWithName(name string, libraries []*types.Library) *types.Library {
 
 func findLibWithNameStartingWith(name string, libraries []*types.Library) *types.Library {
 	for _, library := range libraries {
-		if strings.HasPrefix(library.Name, name) {
+		if strings.HasPrefix(simplifyName(library.Name), simplifyName(name)) {
 			return library
 		}
 	}
@@ -236,7 +236,7 @@ func findLibWithNameStartingWith(name string, libraries []*types.Library) *types
 
 func findLibWithNameEndingWith(name string, libraries []*types.Library) *types.Library {
 	for _, library := range libraries {
-		if strings.HasSuffix(library.Name, name) {
+		if strings.HasSuffix(simplifyName(library.Name), simplifyName(name)) {
 			return library
 		}
 	}
@@ -245,11 +245,15 @@ func findLibWithNameEndingWith(name string, libraries []*types.Library) *types.L
 
 func findLibWithNameContaining(name string, libraries []*types.Library) *types.Library {
 	for _, library := range libraries {
-		if strings.Contains(library.Name, name) {
+		if strings.Contains(simplifyName(library.Name), simplifyName(name)) {
 			return library
 		}
 	}
 	return nil
+}
+
+func simplifyName(name string) string {
+	return strings.ToLower(strings.Replace(name, "_", " ", -1))
 }
 
 // thank you golang: I can not use/recycle/adapt utils.SliceContains

--- a/src/arduino.cc/builder/resolve_library.go
+++ b/src/arduino.cc/builder/resolve_library.go
@@ -84,7 +84,10 @@ func ResolveLibrary(ctx *types.Context, header string) *types.Library {
 
 	library = useAlreadyImportedLibraryWithSameNameIfExists(library, importedLibraries)
 
-	libraryResolutionResults[header] = types.LibraryResolutionResult{Library: library, NotUsedLibraries: filterOutLibraryFrom(libraries, library)}
+	libraryResolutionResults[header] = types.LibraryResolutionResult{
+		Library:          library,
+		NotUsedLibraries: filterOutLibraryFrom(libraries, library),
+	}
 
 	return library
 }

--- a/src/arduino.cc/builder/resolve_library.go
+++ b/src/arduino.cc/builder/resolve_library.go
@@ -55,12 +55,12 @@ func ResolveLibrary(ctx *types.Context, header string) *types.Library {
 		return nil
 	}
 
-	if len(libraries) == 1 {
-		return libraries[0]
-	}
-
 	if markImportedLibraryContainsOneOfCandidates(markImportedLibrary, libraries) {
 		return nil
+	}
+
+	if len(libraries) == 1 {
+		return libraries[0]
 	}
 
 	reverse(libraries)

--- a/src/arduino.cc/builder/resolve_library_test.go
+++ b/src/arduino.cc/builder/resolve_library_test.go
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Arduino Builder.
+ *
+ * Arduino Builder is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ * As a special exception, you may use this file as part of a free software
+ * library without restriction.  Specifically, if other files instantiate
+ * templates or use macros or inline functions from this file, or you compile
+ * this file and link it with other files to produce an executable, this
+ * file does not by itself cause the resulting executable to be covered by
+ * the GNU General Public License.  This exception does not however
+ * invalidate any other reasons why the executable file might be covered by
+ * the GNU General Public License.
+ *
+ * Copyright 2017 Arduino LLC (http://www.arduino.cc/)
+ */
+
+package builder
+
+import (
+	"testing"
+
+	"arduino.cc/builder/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBestLibraryWithHeader(t *testing.T) {
+	l1 := &types.Library{Name: "Calculus Lib"}
+	l2 := &types.Library{Name: "Calculus Lib-master"}
+	l3 := &types.Library{Name: "Calculus Lib Improved"}
+	l4 := &types.Library{Name: "Another Calculus Lib"}
+	l5 := &types.Library{Name: "Yet Another Calculus Lib Improved"}
+	l6 := &types.Library{Name: "AnotherLib"}
+
+	// Test exact name matching
+	res := findBestLibraryWithHeader("calculus_lib.h", []*types.Library{l6, l5, l4, l3, l2, l1})
+	require.Equal(t, l1.Name, res.Name)
+
+	// Test exact name with "-master" postfix matching
+	res = findBestLibraryWithHeader("calculus_lib.h", []*types.Library{l6, l5, l4, l3, l2})
+	require.Equal(t, l2.Name, res.Name)
+
+	// Test prefix matching
+	res = findBestLibraryWithHeader("calculus_lib.h", []*types.Library{l6, l5, l4, l3})
+	require.Equal(t, l3.Name, res.Name)
+
+	// Test postfix matching
+	res = findBestLibraryWithHeader("calculus_lib.h", []*types.Library{l6, l5, l4})
+	require.Equal(t, l4.Name, res.Name)
+
+	// Test "contains"" matching
+	res = findBestLibraryWithHeader("calculus_lib.h", []*types.Library{l6, l5})
+	require.Equal(t, l5.Name, res.Name)
+
+	// Test none matching
+	res = findBestLibraryWithHeader("calculus_lib.h", []*types.Library{l6})
+	require.Nil(t, res)
+}


### PR DESCRIPTION
This allows to set the correct library priority, for example, if the library is named "My Library" but the include file is "my_library.h".

/cc @matteosuppo @facchinm 