### PR TITLE
Avoid bailing out if broken symlink is found

### DIFF
--- a/src/arduino.cc/builder/gohasissues/go_has_issues.go
+++ b/src/arduino.cc/builder/gohasissues/go_has_issues.go
@@ -109,7 +109,7 @@ func ReadDir(dirname string) ([]os.FileInfo, error) {
 		info, err := resolveSymlink(dirname, info)
 		if err != nil {
 			// unresolvable symlinks should be skipped silently
-			return nil, nil
+			continue
 		}
 		infos[idx] = info
 	}


### PR DESCRIPTION
This replaces 8bbac23d2535c66aa953951dd9a46d151e94860c and solves #159 (again)