### PR TITLE
Add .settings to the ignored spurious folders

### DIFF
--- a/src/arduino.cc/builder/utils/utils.go
+++ b/src/arduino.cc/builder/utils/utils.go
@@ -162,7 +162,7 @@ func FilterFiles() filterFiles {
 	}
 }
 
-var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true, ".vscode": true}
+var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true, ".vscode": true, ".settings": true}
 
 func IsSCCSOrHiddenFile(file os.FileInfo) bool {
 	return IsSCCSFile(file) || IsHiddenFile(file)


### PR DESCRIPTION
Eclipse CDT adds a `.settings` folder when used as an external editor, which causes Arduino to show the warning `WARNING: Spurious .settings folder in 'xxx' library` for libraries that are edited with Eclipse CDT.

This Pull Request adds the `.settings` folder to the list of already ignored spurious folders.