### PR TITLE
Improve build instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,18 +57,22 @@ See [Doing continuous integration with arduino builder](https://github.com/ardui
 
 You need [Go 1.6.3](https://golang.org/dl/#go1.6.3).
 
-Repo root contains the script `setup_go_env_vars`. Use it as is or as a template for setting up Go environment variables.
-
 To install `codereview/patch` you have to install [Mercurial](https://www.mercurial-scm.org/) first.
 
-Once done, run the following commands:
+To set things up, run the following inside the cloned arduino-builder
+directory:
 
 ```
+export GOPATH=$(pwd)
 go get github.com/go-errors/errors
 go get github.com/stretchr/testify
 go get github.com/jstemmer/go-junit-report
 go build arduino.cc/arduino-builder
 ```
+
+After installing dependencies, you do not need to run the `go get`
+commands again, but you will have to set `GOPATH` again for every shell
+you want to build in.
 
 ### TDD
 

--- a/setup_go_env_vars
+++ b/setup_go_env_vars
@@ -1,3 +1,0 @@
-export PATH=$PATH:/usr/local/go/bin/
-export GOPATH=`pwd`
-export GOROOT=/usr/local/go


### PR DESCRIPTION
This drops the `setup_go_env_vars` script, which is only confusing. It
contained three lines, of which only one (setting `GOPATH`) is always
required and the other two are only relevant when go is manually
installed. In the most common case (go installed through a package
manager), they will even break the build.

Instead of referring to an external script, just show how to set
`GOPATH` in the README itself.

This improvement was prompted by the user confusion found in #244.

Signed-off-by: Matthijs Kooijman <matthijs@stdin.nl>