### PR TITLE
[WE-32] examples cmake export include Arduino.h for Intel boards

### DIFF
--- a/create_cmake_rule.go
+++ b/create_cmake_rule.go
@@ -109,10 +109,10 @@ func (s *ExportProjectCMake) Run(ctx *types.Context) error {
 
 	// Use old ctags method to generate export file
 	commands := []types.Command{
-		&ContainerMergeCopySketchFiles{},
+		//&ContainerMergeCopySketchFiles{},
 		&ContainerAddPrototypes{},
-		&FilterSketchSource{Source: &ctx.Source, RemoveLineMarkers: true},
-		&SketchSaver{},
+		//&FilterSketchSource{Source: &ctx.Source, RemoveLineMarkers: true},
+		//&SketchSaver{},
 	}
 
 	for _, command := range commands {


### PR DESCRIPTION
This PR fixes a make issue of a cmake-exported basic example sketch for an intel up2 board.

- To reproduce:
```
./arduino-builder\
 -compile\
 -hardware /home/rsora/code/apps/arduino-1.8.5/hardware\
 -hardware /home/rsora/.arduino15/packages\
 -tools /home/rsora/code/apps/arduino-1.8.5/tools-builder\
 -tools /home/rsora/code/apps/arduino-1.8.5/hardware/tools/avr\
 -tools /home/rsora/.arduino15/packages\
 -built-in-libraries /home/rsora/code/apps/arduino-1.8.5/libraries\
 -libraries /home/rsora/Arduino/libraries\
 -fqbn=arduino:mraa:up2\
 -ide-version=10805\
 -build-path /tmp/arduino_build_215398\
 -warnings=all\
 -build-cache /tmp/arduino_cache_660389\
 -prefs=build.warn_data_percentage=75\
 -prefs=runtime.tools.linuxuploader.path=/home/rsora/.arduino15/packages/arduino/tools/linuxuploader/1.5.1\
 -prefs=runtime.tools.arm-linux-gcc.path=/home/rsora/.arduino15/packages/arduino/tools/arm-linux-gcc/4.9.3\
 -prefs=runtime.tools.x86-linux-gcc.path=/home/rsora/.arduino15/packages/arduino/tools/x86-linux-gcc/7.2.0\
 -prefs=compiler.export_cmake=true\
 -verbose /home/rsora/code/apps/arduino-1.8.5/examples/01.Basics/AnalogReadSerial/AnalogReadSerial.ino
```
then launch inside the produced `_cmake` folder 
`cmake .`

then launch `make` inside the folder to produce the error:
```
Scanning dependencies of target AnalogReadSerial
[  4%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/popen_nonstdlib.cpp.o
[  8%] Building C object CMakeFiles/AnalogReadSerial.dir/core/sysfs.c.o
[ 12%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/RingBuffer.cpp.o
[ 16%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/WString.cpp.o
[ 20%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/stdlib_noniso.cpp.o
[ 25%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/pulseIn.cpp.o
[ 29%] Building C object CMakeFiles/AnalogReadSerial.dir/core/wiring_analog.c.o
[ 33%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/main.cpp.o
[ 37%] Building C object CMakeFiles/AnalogReadSerial.dir/core/wiring_digital.c.o
[ 41%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/DebugSerial.cpp.o
[ 45%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/IPAddress.cpp.o
[ 50%] Building C object CMakeFiles/AnalogReadSerial.dir/core/twi.c.o
[ 54%] Building C object CMakeFiles/AnalogReadSerial.dir/core/wiring.c.o
[ 58%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/Print.cpp.o
[ 62%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/HardwareSerial.cpp.o
[ 66%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/Tone.cpp.o
[ 70%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/variant/variant.cpp.o
[ 75%] Building C object CMakeFiles/AnalogReadSerial.dir/core/wiring_shift.c.o
[ 79%] Building C object CMakeFiles/AnalogReadSerial.dir/core/interrupt.c.o
[ 83%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/shell.cpp.o
[ 87%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/WMath.cpp.o
[ 91%] Building CXX object CMakeFiles/AnalogReadSerial.dir/core/Stream.cpp.o
[ 95%] Building CXX object CMakeFiles/AnalogReadSerial.dir/sketch/AnalogReadSerial.ino.cpp.o
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp: In function ‘void setup()’:
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp:16:3: error: ‘Serial’ was not declared in this scope
   Serial.begin(9600);
   ^
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp: In function ‘void loop()’:
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp:22:32: error: ‘A0’ was not declared in this scope
   int sensorValue = analogRead(A0);
                                ^
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp:22:34: error: ‘analogRead’ was not declared in this scope
   int sensorValue = analogRead(A0);
                                  ^
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp:24:3: error: ‘Serial’ was not declared in this scope
   Serial.println(sensorValue);
   ^
/tmp/arduino_build_215398/_cmake/sketch/AnalogReadSerial.ino.cpp:25:10: error: ‘delay’ was not declared in this scope
   delay(1);        // delay in between reads for stability
          ^
CMakeFiles/AnalogReadSerial.dir/build.make:590: recipe for target 'CMakeFiles/AnalogReadSerial.dir/sketch/AnalogReadSerial.ino.cpp.o' failed
make[2]: *** [CMakeFiles/AnalogReadSerial.dir/sketch/AnalogReadSerial.ino.cpp.o] Error 1
CMakeFiles/Makefile2:67: recipe for target 'CMakeFiles/AnalogReadSerial.dir/all' failed
make[1]: *** [CMakeFiles/AnalogReadSerial.dir/all] Error 2
Makefile:83: recipe for target 'all' failed
make: *** [all] Error 2
```
this is caused by the missing `#include <Arduino.h>` placed during the preprocessing of the sketch.

- The fix:

removing sub-commands ContainerMergeCopySketchFiles, FilterSketchSource, SketchSaver from ExportProjectCMake fixes the issue

PS: Fix obviously created pairing with @cmaglie :)