### PR TITLE
Ensure that no spurious file is added to AdditionalFiles

### DIFF
--- a/sketch_loader.go
+++ b/sketch_loader.go
@@ -76,7 +76,7 @@ func (s *SketchLoader) Run(ctx *types.Context) error {
 		return i18n.ErrorfWithLogger(logger, constants.MSG_CANT_FIND_SKETCH_IN_PATH, sketchLocation, filepath.Dir(sketchLocation))
 	}
 
-	sketch, err := makeSketch(sketchLocation, allSketchFilePaths, logger)
+	sketch, err := makeSketch(sketchLocation, allSketchFilePaths, ctx.BuildPath, logger)
 	if err != nil {
 		return i18n.WrapError(err)
 	}
@@ -100,7 +100,7 @@ func collectAllSketchFiles(from string) ([]string, error) {
 	return filePaths, i18n.WrapError(err)
 }
 
-func makeSketch(sketchLocation string, allSketchFilePaths []string, logger i18n.Logger) (*types.Sketch, error) {
+func makeSketch(sketchLocation string, allSketchFilePaths []string, buildLocation string, logger i18n.Logger) (*types.Sketch, error) {
 	sketchFilesMap := make(map[string]types.SketchFile)
 	for _, sketchFilePath := range allSketchFilePaths {
 		source, err := ioutil.ReadFile(sketchFilePath)
@@ -123,7 +123,9 @@ func makeSketch(sketchLocation string, allSketchFilePaths []string, logger i18n.
 				otherSketchFiles = append(otherSketchFiles, sketchFile)
 			}
 		} else if ADDITIONAL_FILE_VALID_EXTENSIONS[ext] {
-			additionalFiles = append(additionalFiles, sketchFile)
+			if !strings.Contains(filepath.Dir(sketchFile.Name), buildLocation) {
+				additionalFiles = append(additionalFiles, sketchFile)
+			}
 		} else {
 			return nil, i18n.ErrorfWithLogger(logger, constants.MSG_UNKNOWN_SKETCH_EXT, sketchFile.Name)
 		}

--- a/sketch_loader.go
+++ b/sketch_loader.go
@@ -123,7 +123,7 @@ func makeSketch(sketchLocation string, allSketchFilePaths []string, buildLocatio
 				otherSketchFiles = append(otherSketchFiles, sketchFile)
 			}
 		} else if ADDITIONAL_FILE_VALID_EXTENSIONS[ext] {
-			if !strings.Contains(filepath.Dir(sketchFile.Name), buildLocation) {
+			if !strings.Contains(filepath.Dir(sketchFile.Name), buildLocation) || buildLocation == "" {
 				additionalFiles = append(additionalFiles, sketchFile)
 			}
 		} else {

--- a/wipeout_build_path_if_build_options_changed.go
+++ b/wipeout_build_path_if_build_options_changed.go
@@ -33,7 +33,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/arduino/arduino-builder/builder_utils"
 	"github.com/arduino/arduino-builder/constants"
@@ -85,10 +84,6 @@ func (s *WipeoutBuildPathIfBuildOptionsChanged) Run(ctx *types.Context) error {
 	files, err := gohasissues.ReadDir(buildPath)
 	if err != nil {
 		return i18n.WrapError(err)
-	}
-	// if build path is inside the sketch folder, also wipe ctx.AdditionalFiles
-	if strings.Contains(ctx.BuildPath, filepath.Dir(ctx.SketchLocation)) {
-		ctx.Sketch.AdditionalFiles = ctx.Sketch.AdditionalFiles[:0]
 	}
 	for _, file := range files {
 		os.RemoveAll(filepath.Join(buildPath, file.Name()))


### PR DESCRIPTION
If the build is executed "in place" (inside the sketch folder) intermediate cpp files were added to the AdditionaFiles list.
This was solved (badly) in https://github.com/arduino/arduino-builder/commit/849faa1f40336d51c9b16726213619e3d01cc19d#diff-b54df391d234f64238253f1d968e2e39R89 .

This patch fixes the issue by not including these files in the list in the first place, so we can avoid removing them later.