### PR TITLE
added .pioenvs and .piolibdeps to ignore list

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -152,7 +152,7 @@ func FilterFiles() filterFiles {
 	}
 }
 
-var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true, ".vscode": true, ".settings": true}
+var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true, ".vscode": true, ".settings": true, ".pioenvs": true, ".piolibdeps": true}
 
 func IsSCCSOrHiddenFile(file os.FileInfo) bool {
 	return IsSCCSFile(file) || IsHiddenFile(file)


### PR DESCRIPTION
Done to avoid the error:
```
WARNING: Spurious *** folder in '***' library
```
the two folders cames from Platformio

someone could point out that it would be meaningless to add them since people who have this warning are using platformio and not the Arduino IDE, but really, IMHO, many of them to write fast and simple skecth will still use the Arduino IDE

similar to this PR:
https://github.com/arduino/arduino-builder/issues/70
https://github.com/arduino/arduino-builder/issues/171 fixed with https://github.com/arduino/arduino-builder/commit/d71753a9299f6f97cbef805b672d2ead83ee7bbe