### PR TITLE
added .vs (Visual Studio) to ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,4 @@ atlassian-ide-plugin.xml
 com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
+/.vs

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -152,7 +152,7 @@ func FilterFiles() filterFiles {
 	}
 }
 
-var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true, ".vscode": true, ".settings": true, ".pioenvs": true, ".piolibdeps": true}
+var SOURCE_CONTROL_FOLDERS = map[string]bool{"CVS": true, "RCS": true, ".git": true, ".github": true, ".svn": true, ".hg": true, ".bzr": true, ".vscode": true, ".settings": true, ".pioenvs": true, ".piolibdeps": true, ".vs": true}
 
 func IsSCCSOrHiddenFile(file os.FileInfo) bool {
 	return IsSCCSFile(file) || IsHiddenFile(file)


### PR DESCRIPTION
I'm hoping this is the place to fix warnings like this in the Arduino IDE after having edited libraries in Visual Studio (which creates a `.vs` directory):

```
WARNING: Spurious .vs folder in 'M5Stack' library
WARNING: Spurious .vs folder in 'Json Streaming Parser' library
```