### PR TITLE
[DO NOT MERGE] Fix parallel compilation disregarding -jobs flag

### DIFF
--- a/arduino-builder/main.go
+++ b/arduino-builder/main.go
@@ -207,13 +207,14 @@ func main() {
 		return
 	}
 
-	if *jobsFlag > 0 {
-		runtime.GOMAXPROCS(*jobsFlag)
-	} else {
-		runtime.GOMAXPROCS(runtime.NumCPU())
-	}
-
 	ctx := &types.Context{}
+
+	if *jobsFlag > 0 {
+		ctx.Jobs = *jobsFlag
+	} else {
+		ctx.Jobs = runtime.NumCPU()
+	}
+	runtime.GOMAXPROCS(ctx.Jobs)
 
 	// place here all experimental features that should live under this flag
 	if *experimentalFeatures {

--- a/types/context.go
+++ b/types/context.go
@@ -103,6 +103,9 @@ type Context struct {
 
 	// Experimental: use arduino-preprocessor to create prototypes
 	UseArduinoPreprocessor bool
+
+	// Parallel processes
+	Jobs int
 }
 
 func (ctx *Context) ExtractBuildOptions() properties.Map {


### PR DESCRIPTION
The issue was due to the peculiar way concurrency and parallelism are handled in go.
We used to set GOMAXPROC to 1 to avoid parallelizing the WaitGroup execution.
This would work, in theory, unless the goroutines sleep.
In that case, another goroutine is allowed to start concurrently (only 1 goroutine running in parallel, so GOMAXPROC is happy).
Since our goroutines sleep (wait) after calling gcc, another task is started, without any hard limit, till the WaitGroup is completely spawned.
On systems with limited resources (as RaspberryPi) and cores with lots of files this can trigger an out of memory condition.