### PR TITLE
Fix buildpath regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/arduino/arduino-builder
 go 1.12
 
 require (
-	github.com/arduino/arduino-cli v0.0.0-20190909101745-b3db7a6400cf
+	github.com/arduino/arduino-cli v0.0.0-20190920124130-b6774033151c
 	github.com/arduino/go-paths-helper v0.0.0-20190214132331-c3c98d1bf2e1
 	github.com/arduino/go-properties-orderedmap v0.0.0-20190828172252-05018b28ff6c
 	github.com/go-errors/errors v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/arduino/arduino-cli v0.0.0-20190828173137-fffa451acd60 h1:5jnGjqzOYyS
 github.com/arduino/arduino-cli v0.0.0-20190828173137-fffa451acd60/go.mod h1:mTVK2WsKc1Ehy2ic+rChPLo9N0uf3ZuUVO7C3y4Y04Q=
 github.com/arduino/arduino-cli v0.0.0-20190909101745-b3db7a6400cf h1:MWVsGOfaT0/HzX5PP6/fWiPviu2YzBe1SbPMtX4qb7s=
 github.com/arduino/arduino-cli v0.0.0-20190909101745-b3db7a6400cf/go.mod h1:mTVK2WsKc1Ehy2ic+rChPLo9N0uf3ZuUVO7C3y4Y04Q=
+github.com/arduino/arduino-cli v0.0.0-20190920124130-b6774033151c h1:0ewBEBzUPbdJgXusSiofkoCJbrT2uKex5ZswdawmdAM=
+github.com/arduino/arduino-cli v0.0.0-20190920124130-b6774033151c/go.mod h1:tGmlOZBUyZunMKW2TIwP/ztR2wnfL81+BNNuZaZmXuQ=
 github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c h1:agh2JT96G8egU7FEb13L4dq3fnCN7lxXhJ86t69+W7s=
 github.com/arduino/board-discovery v0.0.0-20180823133458-1ba29327fb0c/go.mod h1:HK7SpkEax/3P+0w78iRQx1sz1vCDYYw9RXwHjQTB5i8=
 github.com/arduino/go-paths-helper v0.0.0-20190214132331-c3c98d1bf2e1 h1:S0NpDSqjlkNA510vmRCP5Cq9mPgu3rWDSdeN4SI1Mwc=

--- a/main.go
+++ b/main.go
@@ -300,13 +300,13 @@ func main() {
 	}
 
 	// FLAG_BUILD_PATH
-	buildPathUnquoted, err := gohasissues.Unquote(*buildPathFlag)
-	if err != nil {
-		printCompleteError(err)
-	}
-	buildPath := paths.New(buildPathUnquoted)
-	if buildPath != nil {
-		// TODO: mmmmhhh... this one looks like a bug, why check existence?
+	if *buildPathFlag != "" {
+		buildPathUnquoted, err := gohasissues.Unquote(*buildPathFlag)
+		if err != nil {
+			printCompleteError(err)
+		}
+		buildPath := paths.New(buildPathUnquoted)
+
 		if _, err := buildPath.Stat(); err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
@@ -384,6 +384,7 @@ func main() {
 		ctx.SetLogger(i18n.HumanLogger{})
 	}
 
+	var err error
 	if *dumpPrefsFlag {
 		err = builder.RunParseHardwareAndDumpBuildProperties(ctx)
 	} else if *preprocessFlag || *codeCompleteAtFlag != "" {

--- a/main.go
+++ b/main.go
@@ -258,9 +258,9 @@ func main() {
 	if toolsFolders, err := toSliceOfUnquoted(toolsFoldersFlag); err != nil {
 		printCompleteError(err)
 	} else if len(toolsFolders) > 0 {
-		ctx.ToolsDirs = paths.NewPathList(toolsFolders...)
+		ctx.BuiltInToolsDirs = paths.NewPathList(toolsFolders...)
 	}
-	if len(ctx.ToolsDirs) == 0 {
+	if len(ctx.BuiltInToolsDirs) == 0 {
 		printErrorMessageAndFlagUsage(errors.New("Parameter '" + FLAG_TOOLS + "' is mandatory"))
 	}
 


### PR DESCRIPTION
WIP: do not merge before https://github.com/arduino/arduino-cli/pull/418

There were actually two bugs:

- the command line parsing check, to see if the `build-path` parameter has been passed, should be done against the empty string (`""`) and not against `nil`
- the old `ctx.ToolsDirs` parameter has been replaced by `ctx.BuiltInToolsDirs` but this has not been reflected in the builder main.go

Not related with this PR but required to compile:
- the function Unquote has been moved from arduino-cli to this repository

Should fix #336